### PR TITLE
Aligned action chip with attachment icon in fragment_editor_task.xml

### DIFF
--- a/app/src/main/res/layout/fragment_editor_task.xml
+++ b/app/src/main/res/layout/fragment_editor_task.xml
@@ -297,6 +297,7 @@
                     android:layout_weight="1"
                     android:layout_marginEnd="@dimen/container_padding_regular"
                     android:layout_gravity="center"
+                    android:padding="4dp"
                     android:minHeight="@dimen/editor_item_height"
                     android:orientation="vertical">
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jul 18 09:30:42 SGT 2022
+#Wed May 10 13:15:17 IST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
I fixed the padding of linear layout that contains addAction button chip in fragment_editor_task, the button was not aligned with the attachment icon, adding an extra top margin aligned it properly making it look balanced. 